### PR TITLE
Update deprecated Image.ANTIALIAS to Image.LANCZOS

### DIFF
--- a/mosaic.py
+++ b/mosaic.py
@@ -30,8 +30,8 @@ class TileProcessor:
 			h_crop = (h - min_dimension) / 2
 			img = img.crop((w_crop, h_crop, w - w_crop, h - h_crop))
 
-			large_tile_img = img.resize((TILE_SIZE, TILE_SIZE), Image.ANTIALIAS)
-			small_tile_img = img.resize((int(TILE_SIZE/TILE_BLOCK_SIZE), int(TILE_SIZE/TILE_BLOCK_SIZE)), Image.ANTIALIAS)
+			large_tile_img = img.resize((TILE_SIZE, TILE_SIZE), Image.LANCZOS)
+			small_tile_img = img.resize((int(TILE_SIZE/TILE_BLOCK_SIZE), int(TILE_SIZE/TILE_BLOCK_SIZE)), Image.LANCZOS)
 
 			return (large_tile_img.convert('RGB'), small_tile_img.convert('RGB'))
 		except:
@@ -67,7 +67,7 @@ class TargetImage:
 		img = Image.open(self.image_path)
 		w = img.size[0] * ENLARGEMENT
 		h = img.size[1]	* ENLARGEMENT
-		large_img = img.resize((w, h), Image.ANTIALIAS)
+		large_img = img.resize((w, h), Image.LANCZOS)
 		w_diff = (w % TILE_SIZE)/2
 		h_diff = (h % TILE_SIZE)/2
 		
@@ -75,7 +75,7 @@ class TargetImage:
 		if w_diff or h_diff:
 			large_img = large_img.crop((w_diff, h_diff, w - w_diff, h - h_diff))
 
-		small_img = large_img.resize((int(w/TILE_BLOCK_SIZE), int(h/TILE_BLOCK_SIZE)), Image.ANTIALIAS)
+		small_img = large_img.resize((int(w/TILE_BLOCK_SIZE), int(h/TILE_BLOCK_SIZE)), Image.LANCZOS)
 
 		image_data = (large_img.convert('RGB'), small_img.convert('RGB'))
 


### PR DESCRIPTION
Simple change to update support for more recent versions of PILLOW, ANTIALIAS has been changed since PILLOW 2.7.0 to LANCZOS.

Read more [here](https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html)